### PR TITLE
Add capability to toggle route add of default route to main route table

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -40,13 +40,20 @@ config_file="/etc/sysconfig/network-scripts/ifcfg-${INTERFACE}"
 route_file="/etc/sysconfig/network-scripts/route-${INTERFACE}"
 route6_file="/etc/sysconfig/network-scripts/route6-${INTERFACE}"
 dhclient_file="/etc/dhcp/dhclient-${INTERFACE}.conf"
+MAINROUTETABLE="yes"
 
-# make no changes to unmanaged interfaces
+
 if [ -s ${config_file} ]; then
+  # make no changes to unmanaged interfaces
   unmanaged=$(LANG=C grep -l "^[[:space:]]*EC2SYNC=no\([[:space:]#]\|$\)" $config_file)
   if [ "${config_file}" == "${unmanaged}" ]; then
     logger --tag ec2net "Not managing ${INTERFACE}"
     exit
+  fi
+  # check to see if we should add a default route through ${INTERFACE} to the main kernel route table
+  no_default_route=$(LANG=C grep -l "^[[:space:]]*MAINROUTETABLE=no\([[:space:]#]\|$\)" $config_file)
+  if [ "${no_default_route}" == "${config_file}" ]; then
+    MAINROUTETABLE="no"
   fi
 fi
 
@@ -190,12 +197,18 @@ rewrite_primary() {
 	HWADDR=${HWADDR}
 	DEFROUTE=no
 	EC2SYNC=yes
+	MAINROUTETABLE=${MAINROUTETABLE}
 EOF
   cat <<- EOF > ${route_file}
 	default via ${gateway} dev ${INTERFACE} table ${RTABLE}
-	default via ${gateway} dev ${INTERFACE} metric ${RTABLE}
 	${cidr} dev ${INTERFACE} proto kernel scope link src ${primary_ipv4} table ${RTABLE}
 EOF
+  if [ "${MAINROUTETABLE}" == "yes" ]; then
+	logger --tag ec2net "[rewrite_primary] adding default route to main table for ${INTERFACE}"
+	cat <<- EOF >> ${route_file}
+	default via ${gateway} dev ${INTERFACE} metric ${RTABLE}
+EOF
+  fi
   # We would normally write to ${route6_file} here but the
   # gateway is an fe80:: link local address that we get from the
   # RA. We only get an RA if the interface has an IPv6 address.


### PR DESCRIPTION
*Description of changes:*:

This change adds the capability to toggle the addition of the interface's default route to the main kernel route table.

This can be necessary for security reasons in certain uses cases; an example scenario could be one where a cross-account ENI attachment is used to connect two VPCs owned by separate organizations. 

*Testing*

Case 1) MAINROUTETABLE is set to yes before the interface is attached:
```
[ec2-user@ip-172-31-31-118 ~]$ cat /etc/sysconfig/network-scripts/ifcfg-eth1
DEVICE=eth1
BOOTPROTO=none
  IPADDR=172.31.21.38
  NETWORK=172.31.16.0
ONBOOT=yes
TYPE=Ethernet
USERCTL=yes
PEERDNS=no
IPV6INIT=no
DHCPV6C=no
PERSISTENT_DHCLIENT=no
HWADDR=02:b8:59:62:18:ec
DEFROUTE=no
EC2SYNC=no #testing using forked ec2-net-utils, hence this is set to no
MAINROUTETABLE=yes
```


The main route table shows the  default route through eth1, and the custom table shows the correct routes as well
```
ec2-user@ip-172-31-31-118 ~]$ ip route show table 10001
default via 172.31.16.1 dev eth1
172.31.16.0/20 dev eth1


[ec2-user@ip-172-31-31-118 ~]$ ip route show table main
default via 172.31.16.1 dev eth0
default via 172.31.16.1 dev eth1 metric 10001
169.254.169.254 dev eth0
172.31.0.0/16 dev eth1 proto kernel scope link src 172.31.21.38
172.31.16.0/20 dev eth0 proto kernel scope link src 172.31.31.118
```

systemd logs show the interface was set up successfully and the default route was added
```
[ec2-user@ip-172-31-17-217 network-scripts]$ journalctl -u eksnet-ifup@eth1
-- Logs begin at Tue 2020-03-31 23:52:30 UTC, end at Wed 2020-04-01 17:15:30 UTC. --
Mar 31 23:53:00 ip-172-31-17-217.us-west-2.compute.internal systemd[1]: Started Enable customer elastic network interface eth1.
Mar 31 23:53:00 ip-172-31-17-217.us-west-2.compute.internal systemd[1]: Starting Enable customer elastic network interface eth1...
Mar 31 23:53:00 ip-172-31-17-217.us-west-2.compute.internal ec2net[4600]: [plug_interface] eth1 plugged
Mar 31 23:53:00 ip-172-31-17-217.us-west-2.compute.internal ec2net[4608]: [rewrite_primary] Rewriting configs for eth1
Mar 31 23:53:00 ip-172-31-17-217.us-west-2.compute.internal ec2net[4611]: [get_meta] Getting token for IMDSv2
Mar 31 23:53:00 ip-172-31-17-217.us-west-2.compute.internal ec2net[4614]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:01 ip-172-31-17-217.us-west-2.compute.internal ec2net[4618]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:01 ip-172-31-17-217.us-west-2.compute.internal ec2net[4622]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:02 ip-172-31-17-217.us-west-2.compute.internal ec2net[4626]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:02 ip-172-31-17-217.us-west-2.compute.internal ec2net[4630]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:03 ip-172-31-17-217.us-west-2.compute.internal ec2net[4634]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:03 ip-172-31-17-217.us-west-2.compute.internal ec2net[4638]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:04 ip-172-31-17-217.us-west-2.compute.internal ec2net[4642]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:04 ip-172-31-17-217.us-west-2.compute.internal ec2net[4646]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:05 ip-172-31-17-217.us-west-2.compute.internal ec2net[4650]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:05 ip-172-31-17-217.us-west-2.compute.internal ec2net[4654]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:06 ip-172-31-17-217.us-west-2.compute.internal ec2net[4659]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:06 ip-172-31-17-217.us-west-2.compute.internal ec2net[4663]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:07 ip-172-31-17-217.us-west-2.compute.internal ec2net[4667]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:07 ip-172-31-17-217.us-west-2.compute.internal ec2net[4671]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:08 ip-172-31-17-217.us-west-2.compute.internal ec2net[4675]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:09 ip-172-31-17-217.us-west-2.compute.internal ec2net[4679]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:09 ip-172-31-17-217.us-west-2.compute.internal ec2net[4683]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:10 ip-172-31-17-217.us-west-2.compute.internal ec2net[4687]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/subnet-ipv4-cidr-block
Mar 31 23:53:10 ip-172-31-17-217.us-west-2.compute.internal ec2net[4702]: [get_meta] Getting token for IMDSv2
Mar 31 23:53:10 ip-172-31-17-217.us-west-2.compute.internal ec2net[4705]: [get_meta] Trying to get http://169.254.169.254/latest/meta-data/network/interfaces/macs/02:86:6f:7b:4f:5a/local-ipv4s
Mar 31 23:53:10 ip-172-31-17-217.us-west-2.compute.internal ec2net[4710]: [rewrite_primary] adding default route to main table for eth1
Mar 31 23:53:10 ip-172-31-17-217.us-west-2.compute.internal ec2net[4714]: [activate_primary] Activating eth1
```

Case 2) MAINROUTETABLE is set to no before the ENI is attached:
```
[ec2-user@ip-172-31-17-125 ~]$ cat /etc/sysconfig/network-scripts/ifcfg-eth1
DEVICE=eth1
BOOTPROTO=none
  IPADDR=172.31.20.253
  NETWORK=172.31.16.0
ONBOOT=yes
TYPE=Ethernet
USERCTL=yes
PEERDNS=no
IPV6INIT=no
DHCPV6C=no
PERSISTENT_DHCLIENT=no
HWADDR=02:28:6b:ac:8a:b6
DEFROUTE=no
  EC2SYNC=no #testing using forked ec2-net-utils, hence this is set to no
  MAINROUTETABLE=no
```

The main route table shows no  default route through eth1, and the custom table shows the correct routes as well
```
[ec2-user@ip-172-31-17-125 ~]$ route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         172.31.16.1     0.0.0.0         UG    0      0        0 eth0
169.254.169.254 0.0.0.0         255.255.255.255 UH    0      0        0 eth0
172.31.0.0      0.0.0.0         255.255.0.0     U     0      0        0 eth1
172.31.16.0     0.0.0.0         255.255.240.0   U     0      0        0 eth0

[ec2-user@ip-172-31-17-125 ~]$ ip route show table 10001
default via 172.31.16.1 dev eth1
172.31.16.0/20 dev eth1
[ec2-user@ip-172-31-17-125 ~]$
```


systemd logs show interface was set up successfully



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
