### PR TITLE
rpmbuild expects three-character month

### DIFF
--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -126,7 +126,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc %{_mandir}/man8/ec2ifscan.8.gz
 
 %changelog
-* Wed June  3 2020 Frederick Lefebvre <fredlef@amazon.com> 1.4-1
+* Wed Jun  3 2020 Frederick Lefebvre <fredlef@amazon.com> 1.4-1
 - Rename package to match the name of the git repo
 - Fix installation on non-systemd environments
 - Support toggling default route through {INTERFACE} to main kernel route table [Prithvi Ramesh]


### PR DESCRIPTION
*Description of changes:*

rpmbuild's changelog parsing fails on "June" in the date string. Simply changing to "Jun" fixes this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
