### PR TITLE
Better handle IMDS temporary unavailability

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -59,13 +59,33 @@ fi
 
 get_meta() {
   logger --tag ec2net "[get_meta] Getting token for IMDSv2"
-  imds_token=$(curl -s -f -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" ${METADATA_BASEURL}/${METADATA_TOKEN_PATH})
-  imds_exitcode=$?
+
+  # IMDS may have become temporarily unreachable, retry
+  attempts=60
+  imds_exitcode=1
+  while [ "${imds_exitcode}" -gt 0 ]; do
+    if [ "${attempts}" -eq 0 ]; then
+      logger --tag ec2net "[get_meta] Failed to get IMDSv2 metadata token"
+      return $imds_exitcode
+    fi
+
+    imds_token=$(curl -s -f -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" ${METADATA_BASEURL}/${METADATA_TOKEN_PATH})
+    imds_exitcode=$?
+    if [ "${imds_exitcode}" -gt 0 ]; then
+	logger --tag ec2net "[get_meta] Failed to get IMDSv2 token from ${METADATA_BASEURL}/${METADATA_TOKEN_PATH}"
+	logger --tag ec2net "[get_meta] Retrying... ${attempts} remaining"
+	let attempts--
+	sleep 0.5
+	imds_exitcode=1
+    fi
+  done
+
   if [ "${imds_exitcode}" -gt 0 ]; then
-    logger --tag ec2net "[get_meta] Failed to get IMDSv2 token from ${METADATA_BASEURL}/${METADATA_TOKEN_PATH}"
-    logger --tag ec2net "[get_meta] Is Instance Metadata disabled? Aborting"
-    return $imds_exitcode
+      logger --tag ec2net "[get_meta] Failed to get IMDSv2 token from ${METADATA_BASEURL}/${METADATA_TOKEN_PATH}"
+      logger --tag ec2net "[get_meta] Aborting!"
+      return $imds_exitcode
   fi
+
   # IMDS can take up to 30s to provide the information of a new ENI
   attempts=60
   imds_exitcode=1

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -60,48 +60,59 @@ fi
 get_meta() {
   logger --tag ec2net "[get_meta] Getting token for IMDSv2"
   imds_token=$(curl -s -f -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" ${METADATA_BASEURL}/${METADATA_TOKEN_PATH})
-  if [ "${?}" -gt 0 ]; then
+  imds_exitcode=$?
+  if [ "${imds_exitcode}" -gt 0 ]; then
     logger --tag ec2net "[get_meta] Failed to get IMDSv2 token from ${METADATA_BASEURL}/${METADATA_TOKEN_PATH}"
     logger --tag ec2net "[get_meta] Is Instance Metadata disabled? Aborting"
-    return
+    return $imds_exitcode
   fi
   # IMDS can take up to 30s to provide the information of a new ENI
   attempts=60
-  false
-  while [ "${?}" -gt 0 ]; do
+  imds_exitcode=1
+  while [ "${imds_exitcode}" -gt 0 ]; do
     if [ "${attempts}" -eq 0 ]; then
       logger --tag ec2net "[get_meta] Failed to get ${METADATA_BASEURL}/${METADATA_MAC_PATH}/${HWADDR}/${1}"
-      return
+      return $imds_exitcode
     fi
     logger --tag ec2net "[get_meta] Trying to get ${METADATA_BASEURL}/${METADATA_MAC_PATH}/${HWADDR}/${1}"
     meta=$(curl -s -H "X-aws-ec2-metadata-token:${imds_token}" -f ${METADATA_BASEURL}/${METADATA_MAC_PATH}/${HWADDR}/${1})
-    if [ "${?}" -gt 0 ]; then
+    imds_exitcode=$?
+    if [ "${imds_exitcode}" -gt 0 ]; then
       let attempts--
       sleep 0.5
-      false
+      imds_exitcode=1
     fi
   done
   echo "${meta}"
+  return $imds_exitcode
 }
 
 get_cidr() {
   cidr=$(get_meta 'subnet-ipv4-cidr-block')
+  ec=$?
   echo "${cidr}"
+  return $ec
 }
 
 get_ipv4s() {
   ipv4s=$(get_meta 'local-ipv4s')
+  ec=$?
   echo "${ipv4s}"
+  return $ec
 }
 
 get_primary_ipv4() {
   ipv4s=($(get_ipv4s))
+  ec=$?
   echo "${ipv4s[0]}"
+  return $ec
 }
 
 get_secondary_ipv4s() {
   ipv4s=($(get_ipv4s))
+  ec=$?
   echo "${ipv4s[@]:1}"
+  return $ec
 }
 
 get_ipv6s() {
@@ -176,6 +187,12 @@ rewrite_primary() {
   fi
   logger --tag ec2net "[rewrite_primary] Rewriting configs for ${INTERFACE}"
   cidr=$(get_cidr)
+  if [ "${?}" -gt 0 ]; then
+    # For any errors from IMDS, bail out early rather than rewriting anything
+    # We'll get back here later and be able to rewrite things.
+    logger --tag ec2net "[rewrite_primary] Error $? contacting IMDS for ${INTERFACE}. Bailing out."
+    return $?
+  fi
   if [ -z ${cidr} ]; then
     return
   fi
@@ -291,8 +308,20 @@ rewrite_rules() {
   if [ "${INTERFACE}" == "eth0" ]; then
     return
   fi
+
   ips=($(get_ipv4s))
+  if [ $? -gt 0 ]; then
+    # If we get an error fetching the list of IPs from IMDS,
+    # bail out early.
+    return
+  fi
   ip6s=($(get_ipv6s))
+  if [ $? -gt 0 ]; then
+    # If we get an error fetching the list of IPs from IMDS,
+    # bail out early.
+    return
+  fi
+
   if [ ${#ips[*]} -eq 0 ]; then
     remove_rules
     return

--- a/test-ec2-net-utils.py
+++ b/test-ec2-net-utils.py
@@ -1,0 +1,226 @@
+#!/usr/bin/python2
+'''
+A simple test case for ENI attach/detach with error injection for talking
+to IMDS. Intended to be run on an instance with AWS credentials already set up.
+'''
+
+import unittest
+
+import urllib2
+
+import boto3
+import botocore
+from datetime import datetime
+import json
+import subprocess
+import re
+import time
+        
+def log(error):
+    print('{}Z {}'.format(datetime.utcnow().isoformat(), error))
+
+
+class InstanceManipulator():
+    def get_instance_id(self):
+        opener = urllib2.build_opener(urllib2.HTTPHandler)
+        token_request = urllib2.Request(url="http://169.254.169.254/latest/api/token")
+        token_request.add_header('X-aws-ec2-metadata-token-ttl-seconds', 20)
+        token_request.get_method = lambda: 'PUT'
+        token = opener.open(token_request).read()
+
+        id_request = urllib2.Request(url='http://169.254.169.254/latest/meta-data/instance-id')
+        id_request.add_header('X-aws-ec2-metadata-token', token)
+        return opener.open(id_request).read()
+
+    def get_region(self):
+        opener = urllib2.build_opener(urllib2.HTTPHandler)
+        token_request = urllib2.Request(url="http://169.254.169.254/latest/api/token")
+        token_request.add_header('X-aws-ec2-metadata-token-ttl-seconds', 20)
+        token_request.get_method = lambda: 'PUT'
+        token = opener.open(token_request).read()
+
+        id_request = urllib2.Request(url='http://169.254.169.254/latest/dynamic/instance-identity/document')
+        id_request.add_header('X-aws-ec2-metadata-token', token)
+        self.identity_doc = json.loads(opener.open(id_request).read())
+        return self.identity_doc['region']
+        
+    def __init__(self):
+        self.instance_id = self.get_instance_id()
+        self.region = self.get_region()
+        self.ec2_client = boto3.client('ec2', region_name=self.region)
+
+
+    def get_subnet_id(self, instance_id):
+        try:
+            result = self.ec2_client.describe_instances(InstanceIds=[self.instance_id])
+            vpc_subnet_id = result['Reservations'][0]['Instances'][0]['SubnetId']
+            log("Subnet id: {}".format(vpc_subnet_id))
+
+        except botocore.exceptions.ClientError as e:
+            log("Error describing the instance {}: {}".format(self.instance_id, e.response['Error']))
+            vpc_subnet_id = None
+
+        return vpc_subnet_id
+
+
+    def create_interface(self, subnet_id):
+        network_interface_id = None
+
+        if subnet_id:
+            try:
+                network_interface = self.ec2_client.create_network_interface(SubnetId=subnet_id)
+                network_interface_id = network_interface['NetworkInterface']['NetworkInterfaceId']
+                log("Created network interface: {}".format(network_interface_id))
+            except botocore.exceptions.clientError as e:
+                log("Error creating network interface: {}".format(e.response['Error']))
+
+        return network_interface_id
+
+
+    def attach_interface(self, network_interface_id, instance_id, device_index=1):
+        attachment = None
+
+        if network_interface_id and instance_id:
+            try:
+                attach_interface = self.ec2_client.attach_network_interface(
+                    NetworkInterfaceId=network_interface_id,
+                    InstanceId=instance_id,
+                    DeviceIndex=device_index
+                    )
+                attachment = attach_interface['AttachmentId']
+                log("Created network attachment: {}".format(attachment))
+            except botocore.exceptions.ClientError as e:
+                log("Error attaching network interface: {}".format(e.response['Error']))
+                raise e
+
+        return attachment
+
+    def detach_interface(self, attachment_id):
+        try:
+            self.ec2_client.detach_network_interface(
+                AttachmentId=attachment_id
+                )
+            log("Detached network interface: {}".format(attachment_id))
+            return True
+
+        except botocore.exceptions.ClientError as e:
+            log("Error detaching interface {}: {}".format(attachment_id, e.response['Error']))
+            return False
+
+    def delete_interface(self, network_interface_id):
+        deleted = False
+        tries = 30
+        while not deleted:
+            try:
+                self.ec2_client.delete_network_interface(
+                    NetworkInterfaceId=network_interface_id
+                    )
+                log("Deleted network interface: {}".format(network_interface_id))
+                return True
+
+            except botocore.exceptions.ClientError as e:
+                log("Error deleting interface {}: {}".format(network_interface_id, e.response['Error']))
+                time.sleep(1)
+                tries = tries - 1
+                if tries == 0:
+                    return False
+
+def verify_interface(interface_nr=1):
+    ip = None
+    time_remaining = 40
+
+    while ip is None:
+        process = subprocess.Popen(['/sbin/ifconfig', 'eth{}'.format(interface_nr)],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+        print stdout,stderr
+
+        m = re.search(r'inet ([0-9.]+)', stdout)
+        if m is not None:
+            ip = m.group(0)
+
+        time.sleep(1)
+        time_remaining -= 1
+        if time_remaining == 0:
+            return False
+        
+    return True
+
+def ifdown(interface_nr=1):
+    r = subprocess.call(['/sbin/ec2ifdown', 'eth{}'.format(interface_nr)])
+    if r == 0:
+        return True
+    return False
+    
+class BasicENI(unittest.TestCase):
+
+    def test_add_remove(self):
+        '''
+        Very basic add/remove of ENI. Verify interface gets an IP.
+        '''
+        instance = InstanceManipulator()
+        subnet_id = instance.get_subnet_id(instance.get_instance_id())
+        interface_id = instance.create_interface(subnet_id)
+        try:
+            attachment = instance.attach_interface(interface_id, instance.get_instance_id())
+        except botocore.exceptions.ClientError as e:
+            self.assertTrue(instance.delete_interface(interface_id),
+                            "Failed deleting interface {} after attach failure".format(interface_id))
+            self.assertTrue(False, "Failed to attach interface: {}".format(e.response))
+            
+        self.assertTrue(interface_id, "Failed creating interface")
+        self.assertTrue(attachment, "Failed to attach interface")
+
+        self.assertTrue(verify_interface(), "Interface didn't come up with IP address")
+
+        # This is implicit with the detach, but for simple test, be explicit to have more test paths
+        self.assertTrue(ifdown(), "Could not ifdown interface")
+
+        self.assertTrue(instance.detach_interface(attachment),
+                        "Failed detaching interface {}, attachment {}".format(interface_id, attachment))
+        self.assertTrue(instance.delete_interface(interface_id),
+                        "Failed deleting interface {}".format(interface_id))
+
+        log("Success")
+
+    def test_add_remove_many(self):
+        '''
+        Add as many ENIs as possible and then remove them.
+        '''
+        instance = InstanceManipulator()
+        subnet_id = instance.get_subnet_id(instance.get_instance_id())
+
+        interfaces = []
+        attached = []
+
+        test_range = range(1,100)
+
+        for i in test_range:
+            interface_id = instance.create_interface(subnet_id)
+
+            try:
+                attached.append(instance.attach_interface(interface_id, instance.get_instance_id(), i))
+            except botocore.exceptions.ClientError as e:
+                if e.response['Error']['Code'] == 'AttachmentLimitExceeded':
+                    instance.delete_interface(interface_id)
+                    log("Limit of {} interfaces reached".format(len(interfaces)))
+                else:
+                    self.assertFalse(False, "EC2 error attaching interface: {}".format(e.response))
+                break
+            else:
+                interfaces.append(interface_id)
+                self.assertTrue(interfaces[-1], "Failed creating interface {}".format(i))
+                self.assertTrue(attached[-1], "Faild to attach interface {}".format(i))
+                log("Created and attached interface number {}".format(len(interfaces)))
+
+        for i in range(0,len(interfaces)):
+            self.assertTrue(verify_interface(i+1), "Interface {} didn't come up with IP address".format(i+1))
+
+        for i in range(0,len(interfaces)):
+            self.assertTrue(instance.detach_interface(attached[i]),
+                            "Failed to detach interface {} ({}) attachment {}".format(i, interfaces[i], attached[i]))
+            self.assertTrue(instance.delete_interface(interfaces[i]), "Failed to delete interface {}".format(i))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This patch set does three interesting things:

1. Fixes a bug where we could wipe out routes if IMDS is temporarily unavailable when renewing DHCP leases
2. Adds a retry for fetching IMDSv2 token
3. Adds a rudimentary test script that hits the relevant code paths

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
