### PR TITLE
Update Provides and Obsoletes entries in spec file

### DIFF
--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -6,8 +6,8 @@
 
 Name:      amazon-ec2-net-utils
 Summary:   A set of network tools for managing ENIs
-Version:   1.4
-Release:   2%{?dist}
+Version:   1.5
+Release:   1%{?dist}
 License:   MIT and GPLv2
 Group:     System Tools
 Source0:   53-ec2-network-interfaces.rules.systemd
@@ -38,7 +38,8 @@ BuildRequires: systemd-units
 Requires: systemd-units
 %endif # systemd
 Requires: dhclient
-Provides: ec2-net-utils
+Provides: ec2-net-utils = %{version}-%{release}
+Obsoletes: ec2-net-utils < 1.5
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description
@@ -127,6 +128,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc %{_mandir}/man8/ec2ifscan.8.gz
 
 %changelog
+* Mon Oct  5 2020 Noah Meyerhans <nmeyerha@amazon.com> 1.5-1
+- Update Provides and Obsoletes to define an upgrade path from ec2-net-utils
+
 * Mon Jul 13 2020 Frederick Lefebvre <fredlef@amazon.com> 1.4-2
 - Provides ec2-net-utils for backward compatibility
 


### PR DESCRIPTION
The amazon-ec2-net-utils package is intended to replace the ec2-net-utils
package, so it needs to be installable as a drop-in replacement.  In order to
do that, it needs both a Provides and Obsoletes relationship with that package
in order to ensure that rpm recognizes it as a replacement.

Additionally, we only want to declare a Provides relationship on versions of
ec2-net-utils that whose functionality we actually implement.  An unversioned
Provides entry means we provide all possible versions, including ancient ones
like 0.4-1, which other packages may legitimate want to conflict with.

This addresses #12 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
