### PR TITLE
Skip udev rule for VLAN interface

### DIFF
--- a/75-persistent-net-generator.rules
+++ b/75-persistent-net-generator.rules
@@ -13,8 +13,8 @@ NAME=="?*", GOTO="persistent_net_generator_end"
 # do not create rule for eth0
 ENV{INTERFACE}=="eth0", GOTO="persistent_net_generator_end"
 
-# do not create rule for VLAN interfaces (e.g. eth1.1)
-ENV{INTERFACE}=="eth*.*", GOTO="persistent_net_generator_end"
+# skip interfaces not supported by ec2-net-utils (e.g. VLAN)
+ENV{ID_NET_DRIVER}!="vif|ena", GOTO="persistent_net_generator_end"
 
 # read MAC address
 ENV{MATCHADDR}="$attr{address}"

--- a/75-persistent-net-generator.rules
+++ b/75-persistent-net-generator.rules
@@ -13,7 +13,7 @@ NAME=="?*", GOTO="persistent_net_generator_end"
 # do not create rule for eth0
 ENV{INTERFACE}=="eth0", GOTO="persistent_net_generator_end"
 
-# skip interfaces not supported by ec2-net-utils (e.g. VLAN)
+# only create rules for vif|ena devices (e.g. skip VLAN)
 ENV{ID_NET_DRIVER}!="vif|ena", GOTO="persistent_net_generator_end"
 
 # read MAC address

--- a/75-persistent-net-generator.rules
+++ b/75-persistent-net-generator.rules
@@ -13,6 +13,9 @@ NAME=="?*", GOTO="persistent_net_generator_end"
 # do not create rule for eth0
 ENV{INTERFACE}=="eth0", GOTO="persistent_net_generator_end"
 
+# do not create rule for VLAN interfaces (e.g. eth1.1)
+ENV{INTERFACE}=="eth*.*", GOTO="persistent_net_generator_end"
+
 # read MAC address
 ENV{MATCHADDR}="$attr{address}"
 


### PR DESCRIPTION
VLAN interfaces require associations with some parent ethernet device. This can cause an issue with udev, which confuses the physical address of the VLAN interface with the parent interface and creates the wrong device rule.

As such, udev rule generation for VLAN interfaces should be skipped. The user of VLAN interface should create the udev rule themselves if needed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
