### PR TITLE
Fix the number of secondary IP (aliases)

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -327,7 +327,7 @@ rewrite_aliases() {
                      |awk '{print $2}'|cut -d/ -f1); do
     secondaries[${secondary}]=1
   done
-  for alias in ${aliases}; do
+  for alias in ${aliases[@]}; do
     if [[ ${secondaries[${alias}]} ]]; then
       unset secondaries[${alias}]
     else

--- a/tests/params-secondary-more-ips.sh
+++ b/tests/params-secondary-more-ips.sh
@@ -20,6 +20,7 @@ get_meta() {
 	local-ipv4s)
 	    echo "192.168.10.21"
 	    echo "192.168.10.22"
+	    echo "192.168.10.23"
 	    ;;
 	ipv4-prefix)
 	    echo "172.16.1.0/24"

--- a/tests/tdata/secondary-more-ips/ec2dhcp.sh.out
+++ b/tests/tdata/secondary-more-ips/ec2dhcp.sh.out
@@ -8,6 +8,7 @@ CALLED logger --tag ec2net [rewrite_rules] Rewriting rules for eth2
 CALLED ip -4 rule list
 CALLED ip -4 rule add from 192.168.10.21 lookup 10002
 CALLED ip -4 rule add from 192.168.10.22 lookup 10002
+CALLED ip -4 rule add from 192.168.10.23 lookup 10002
 CALLED ip -4 rule add from 172.16.1.0/24 lookup 10002
 CALLED ip -6 rule list
 CALLED ip -6 rule add from fd01:ffff:eeee:5:4:3:2:1 lookup 10002
@@ -18,3 +19,4 @@ CALLED logger --tag ec2net [rewrite_aliases] Rewriting aliases of eth2
 CALLED get_meta subnet-ipv4-cidr-block
 CALLED ip -4 addr list dev eth2 secondary
 CALLED ip -4 addr add 192.168.10.22/24 brd + dev eth2
+CALLED ip -4 addr add 192.168.10.23/24 brd + dev eth2


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
When the number of secondary IP is greater than 1, ${aliases} can only get the first element(same as ${aliases[0]}).
By modifying it to ${aliases[@]}, all elements can be traversed.

Changes:
Pathch rewrite_aliases()
${aliases} -> ${aliases[@]}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
