### PR TITLE
Ignore interfaces that use unrecognized drivers

### DIFF
--- a/75-persistent-net-generator.rules
+++ b/75-persistent-net-generator.rules
@@ -13,6 +13,9 @@ NAME=="?*", GOTO="persistent_net_generator_end"
 # do not create rule for eth0
 ENV{INTERFACE}=="eth0", GOTO="persistent_net_generator_end"
 
+# do not create rule if interface uses unrecognized driver
+ENV{ID_NET_DRIVER}!="vif|ena|ixgbevf", GOTO="persistent_net_generator_end"
+
 # read MAC address
 ENV{MATCHADDR}="$attr{address}"
 


### PR DESCRIPTION
AWS supports three types of virtual network adapters described here https://aws.amazon.com/premiumsupport/knowledge-center/enable-configure-enhanced-networking/: VIF, Intel 82599 VF, and Elastic Network Adapter. As such, AWS EC2 ENI that can be hot-swapped will be associated with one of those three drivers.

New interfaces that are not associated with any of the three adapters will be an interface type that should not be matched by amazon-ec2-net-utils. One example is branch interfaces provided by VLAN.

*Issue #, if available:*

*Description of changes:* Given in commit message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
