### PR TITLE
Configure Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,29 @@ jobs:
           command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make"
       - run:
           command: "make test"
+  al2-rpm-scratch:
+    docker:
+      - image: public.ecr.aws/amazonlinux/amazonlinux:2
+    steps:
+      - checkout
+      - run:
+          name: "Install dependencies"
+          command: "yum -y install rpm-build make systemd-units git"
+      - run:
+          name: "Repack sources"
+          command: |
+            v=$(rpmspec -q --qf "%{version}" amazon-ec2-net-utils.spec)
+            make scratch-sources
+            mkdir ../amazon-ec2-net-utils-${v}
+            zcat ../amazon-ec2-net-utils*.tar.gz | tar -C ../amazon-ec2-net-utils-${v} -xf - --strip-components=2
+            tar cvzf ${v}.tar.gz ../amazon-ec2-net-utils-${v}
+      - run:
+          name: "rpmbuild"
+          command: rpmbuild --define "_sourcedir $PWD" -bb amazon-ec2-net-utils.spec
 
 workflows:
   ci-workflow:
     jobs:
       - code-checks
       - tests
+      - al2-rpm-scratch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2.1
+
+jobs:
+  code-checks:
+    docker:
+      - image: public.ecr.aws/debian/debian:11
+    steps:
+      - checkout
+      - run:
+          name: "Install dependencies"
+          command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install shellcheck"
+      - run:
+          name: "shellcheck"
+          command: "shellcheck -s bash -S error ec2dhcp.sh ec2ifdown ec2ifup ec2ifscan ec2net-functions write_net_rules"
+  tests:
+    docker:
+      - image: public.ecr.aws/debian/debian:11
+    steps:
+      - checkout
+      - run:
+          name: "Install dependencies"
+          command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make"
+      - run:
+          command: "make test"
+
+workflows:
+  ci-workflow:
+    jobs:
+      - code-checks
+      - tests

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ mandir=${DESTDIR}/${prefix}/share/man
 init=systemd
 
 define install-file
-test -d $2 || install -d -o root -g root -m755 $2
-install -o root -g root -m644 $1 $2
+test -d $2 || install -d -m755 $2
+install -m644 $1 $2
 endef
 
 define install-exe
-test -d $2 || install -d -o root -g root -m755 $2
-install -o root -g root -m755 $1 $2
+test -d $2 || install -d -m755 $2
+install -m755 $1 $2
 endef
 
 CLEANFILES:=

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -50,23 +50,23 @@ MAINROUTETABLE="yes"
 
 
 function ip() {
-    command "$FUNCNAME" $@
+    command "$FUNCNAME" "$@"
 }
 
 function ifup() {
-    command "$FUNCNAME" $@
+    command "$FUNCNAME" "$@"
 }
 
 function ifdown() {
-    command "$FUNCNAME" $@
+    command "$FUNCNAME" "$@"
 }
 
 function logger() {
-    command "$FUNCNAME" $@
+    command "$FUNCNAME" "$@"
 }
 
 function rm() {
-    command "$FUNCNAME" $@
+    command "$FUNCNAME" "$@"
 }
 
 if [ -s ${config_file} ]; then
@@ -200,7 +200,7 @@ get_ipv6_gateway() {
     quibbles[1]=$(( 0x${octets[2]}ff ))
     quibbles[2]=$(( 0xfe00 + 0x${octets[3]} ))
     quibbles[3]=$(( (0x${octets[4]} << 8) + 0x${octets[5]} ))
-    printf "fe80::%04x:%04x:%04x:%04x\n" ${quibbles[@]}
+    printf "fe80::%04x:%04x:%04x:%04x\n" "${quibbles[@]}"
   else
     logger --tag ec2net "[get_ipv6_gateway] Waiting for IPv6 router advertisement"
     attempts=20
@@ -330,7 +330,7 @@ rewrite_aliases() {
                      |awk '{print $2}'|cut -d/ -f1); do
     secondaries[${secondary}]=1
   done
-  for alias in ${aliases[@]}; do
+  for alias in "${aliases[@]}"; do
     if [[ ${secondaries[${alias}]} ]]; then
       unset secondaries[${alias}]
     else
@@ -411,7 +411,7 @@ EOF
     split=(${rule//:/ })
     rules[${split[1]}]=${split[0]}
   done
-  for ip in ${ips[@]}; do
+  for ip in "${ips[@]}"; do
     if [[ ${rules[${ip}]} ]]; then
       unset rules[${ip}]
     else
@@ -429,7 +429,7 @@ EOF
     split=(${rule/:/ }) # take care to only replace the first :
     rules6[${split[1]}]=${split[0]}
   done
-  for ip in ${ip6s[@]}; do
+  for ip in "${ip6s[@]}"; do
     if [[ ${rules6[${ip}]} ]]; then
       unset rules6[${ip}]
     else


### PR DESCRIPTION
Add Circle CI configuration and some basic jobs.

The jobs:
* run shellcheck on bash components
* run `make test`
* build an RPM on Amazon Linux 2

Included in this PR are changes to address some issues encountered while setting this up:

1. Stop trying to set ownership of files installed during `make install`
2. Fix some shellcheck errors
3. Fix tag identification and dirty repo detection in `make sources`

Addresses #20 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
