### PR TITLE
Skip retries when IMDS queries for *-prefix keys fail

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -117,6 +117,10 @@ get_meta() {
     logger --tag ec2net "[get_meta] Trying to get ${METADATA_BASEURL}/${METADATA_MAC_PATH}/${HWADDR}/${1}"
     meta=$(curl -s -H "X-aws-ec2-metadata-token:${imds_token}" -f ${METADATA_BASEURL}/${METADATA_MAC_PATH}/${HWADDR}/${1})
     imds_exitcode=$?
+    # Temporary hack to avoid retries on prefix delegation keys that don't actually exist yet:
+    if [[ "$1" = *-prefix ]]; then
+        break
+    fi
     if [ "${imds_exitcode}" -gt 0 ]; then
       let attempts--
       sleep 0.5


### PR DESCRIPTION
The Amazon EC2 Instance Metadata Service returns an HTTP 404 error in response to queries for ipv4-prefix and ipv6-prefix keys if there are no delegated prefixes assigned to an ENI.  This makes it impossible for us to distinguish between an actual error and a legitimate configuration in which there are simply no prefixes assigned.  Rather than retry until we get a non-error response that may never actually arrive, we avoid retries altogether when querying prefix keys.

Note that this change is ported from the Amazon Linux 2 package, where it has been deployed since version 1.5-1.amzn2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
