### PR TITLE
CircleCI: install dependencies before checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ jobs:
     docker:
       - image: public.ecr.aws/debian/debian:11
     steps:
-      - checkout
       - run:
           name: "Install dependencies"
-          command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install shellcheck"
+          command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install shellcheck git ssh-client"
+      - checkout
       - run:
           name: "shellcheck"
           command: "shellcheck -s bash -S error ec2dhcp.sh ec2ifdown ec2ifup ec2ifscan ec2net-functions write_net_rules"
@@ -16,20 +16,20 @@ jobs:
     docker:
       - image: public.ecr.aws/debian/debian:11
     steps:
-      - checkout
       - run:
           name: "Install dependencies"
-          command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make"
+          command: "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make git ssh-client"
+      - checkout
       - run:
           command: "make test"
   al2-rpm-scratch:
     docker:
       - image: public.ecr.aws/amazonlinux/amazonlinux:2
     steps:
-      - checkout
       - run:
           name: "Install dependencies"
-          command: "yum -y install rpm-build make systemd-units git"
+          command: "yum -y install rpm-build make systemd-units git ssh-client"
+      - checkout
       - run:
           name: "Repack sources"
           command: |


### PR DESCRIPTION
With GitHub's recent change to enforce stronger hash algorithms, Circle CI was unable to clone the project repository.  By installing our dependencies earlier in the workflow, we are able to ensure that the AL2 git and ssh clients are used, which do support the newer algorithms.

Details in this discussion on the Circle CI forums:
https://discuss.circleci.com/t/discussion-and-resolution-for-error-youre-using-an-rsa-key-with-sha-1-which-is-no-longer-allowed/42572

Addresses #28 

CC @halfdime-code