### PR TITLE
Add set-hostname-imds service

### DIFF
--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -32,9 +32,11 @@ make install DESTDIR=%{buildroot} PREFIX=/usr
 /usr/lib/systemd/system/policy-routes@.service
 /usr/lib/systemd/system/refresh-policy-routes@.service
 /usr/lib/systemd/system/refresh-policy-routes@.timer
+/usr/lib/systemd/system/set-hostname-imds.service
 
 /usr/lib/udev/rules.d/99-vpc-policy-routes.rules
 %{_bindir}/setup-policy-routes
+%{_bindir}/set-hostname-imds
 %dir %{_datarootdir}/amazon-ec2-net-utils
 %{_datarootdir}/amazon-ec2-net-utils/lib.sh
 

--- a/bin/set-hostname-imds.sh
+++ b/bin/set-hostname-imds.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#      http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -eCo pipefail
+
+libdir=${LIBDIR_OVERRIDE:-/usr/share/amazon-ec2-net-utils}
+
+. "${libdir}/lib.sh"
+
+if [ -s /etc/hostname ]; then
+    info "Static hostname is already set - not modifying existing hostname"
+    exit 0
+fi
+
+hostname=$(get_imds local-hostname)
+
+if [ -n "$hostname" ]; then
+    info "Setting hostname to ${hostname} retrieved from IMDS"
+    hostnamectl hostname ${hostname}
+else
+    error "Unable to retrieve hostname from IMDS - aborting"
+    exit 1
+fi

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -71,7 +71,9 @@ get_token() {
     while [ "$(date +%s)" -lt $deadline ]; do
         for ep in "${imds_endpoints[@]}"; do
             set +e
-            imds_token=$(make_token_request "$ep" "$intf")
+            if [ -n "$intf" ]; then
+                imds_token=$(make_token_request "$ep" "$intf")
+            fi
 
             if [ -z "$imds_token" ]; then
                 imds_token=$(make_token_request "$ep")

--- a/systemd/system/set-hostname-imds.service
+++ b/systemd/system/set-hostname-imds.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Sets the local hostname defined in IMDS
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/set-hostname-imds
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds a simple systemd service set-hostname-imds which will retrieve the local-hostname from IMDS and set the system hostname. This service can be used in systems that don't have another solution like cloud-init or systemd-networkd setting the hostname.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
