### PR TITLE
Silence error on lock attempt

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -643,8 +643,8 @@ register_networkd_reloader() {
         # If the redirect fails, most likely because the target file
         # already exists and -o noclobber is in effect, $? will be set
         # nonzero.  If it succeeds, it is set to 0
-        echo $$ > "${lockfile}"
-	# shellcheck disable=SC2320
+        2>/dev/null echo $$ > "${lockfile}"
+        # shellcheck disable=SC2320
         registered=$?
         [ $registered -eq 0 ] && break
         sleep 0.1


### PR DESCRIPTION
Silence the error when attempting to create the lockfile fails.  Diagnostics are still printed every 100 failures, but this single line is filling about 90% of /var/log/messages on deployed systems.

*Issue #, if available:*

NA

*Description of changes:*

This redirects stderr to /dev/null when trying to create the lockfile via stdout redirection.  Without this, the following line fills about 90% of /var/log/messages:
```
Feb 26 08:48:27 pnhost setup-policy-routes[1859]: /usr/share/amazon-ec2-net-utils/lib.sh: line 646: /run/amazon-ec2-net-utils/setup-policy-routes/eth0: cannot overwrite existing file
```

There is already additional code around this write attempt, including a diagnostic message printed every 100 attempts.

It also has a whitespace-only change on the following comment line so the leading whitespace matches the surrounding lines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
