### PR TITLE
Add upstream homepage, remove dpkg-gencontrol false-positive warning

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,13 +4,13 @@ Priority: optional
 Maintainer: Noah Meyerhans <nmeyerha@amazon.com>
 Build-Depends: debhelper-compat (= 12), shellcheck
 Standards-Version: 4.4.1
-Homepage: <insert the upstream URL, if relevant>
+Homepage: https://github.com/amazonlinux/amazon-ec2-net-utils
 #Vcs-Browser: https://salsa.debian.org/debian/amazon-ec2-net-utils
 #Vcs-Git: https://salsa.debian.org/debian/amazon-ec2-net-utils.git
 
 Package: amazon-ec2-net-utils
 Architecture: all
-Depends: systemd, udev, curl, iproute2, bash, coreutils, ${shlibs:Depends}, ${misc:Depends}
+Depends: systemd, udev, curl, iproute2, bash, coreutils, ${misc:Depends}
 Description: utilities for managing network interfaces in Amazon EC2
  amazon-ec2-net-utils provides udev integration and helper utilities
  to manage network configuration in the Amazon EC2 cloud environment


### PR DESCRIPTION
* Added missing upstream homepage URL to debian control file
* Removed "${shlibs:Depends}" from "Depends:" as this package is script-only so that substitution is unnecessary and triggers a warning at build time which can lead to confusion and is just unnecessary noise.

*Description of changes:*

**BEFORE**
```
root@ip-172-31-20-194:/home/ubuntu/amazon-ec2-net-utils# dpkg-buildpackage -uc -us -b
dpkg-buildpackage: info: source package amazon-ec2-net-utils
dpkg-buildpackage: info: source version 2.5.3
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Josiah Vehrs <jvehrs@amazon.com>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
dpkg-source: info: using patch list from debian/patches/series
dpkg-source: info: applying update-networkd-priorities.patch
 debian/rules clean
dh clean
   dh_auto_clean
   dh_clean
 debian/rules build
dh build
   dh_update_autotools_config
   dh_autoreconf
   dh_auto_configure
   dh_auto_test
        make -j16 check
make[1]: Entering directory '/home/ubuntu/amazon-ec2-net-utils'
+ shellcheck --severity warning bin/setup-policy-routes.sh
+ shellcheck --severity warning lib/lib.sh
make[1]: Leaving directory '/home/ubuntu/amazon-ec2-net-utils'
   create-stamp debian/debhelper-build-stamp
 debian/rules binary
dh binary
   dh_testroot
   dh_prep
   dh_installdirs
   dh_auto_install --destdir=debian/amazon-ec2-net-utils/
        make -j16 install DESTDIR=/home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils AM_UPDATE_INFO_DIR=no "INSTALL=install --strip-program=true"
make[1]: Entering directory '/home/ubuntu/amazon-ec2-net-utils'
install -d /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils//usr/share/amazon-ec2-net-utils
tgt=/home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/bin/$(basename --suffix=.sh bin/setup-policy-routes.sh); install -m755 bin/setup-policy-routes.sh $tgt;sed -i "s,AMAZON_EC2_NET_UTILS_LIBDIR,/usr/share/amazon-ec2-net-utils,g" $tgt;
install -m644 lib/lib.sh /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils//usr/share/amazon-ec2-net-utils
install -m644 udev/99-vpc-policy-routes.rules /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/udev/rules.d;
install -m644 systemd/network/80-ec2.network /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/network;
install -m644 systemd/system/policy-routes@.service /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/system; install -m644 systemd/system/refresh-policy-routes@.service /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/system; install -m644 systemd/system/refresh-policy-routes@.timer /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/system;
make[1]: Leaving directory '/home/ubuntu/amazon-ec2-net-utils'
   dh_installdocs
   dh_installchangelogs
   dh_installsystemd
   dh_perl
   dh_link
   dh_strip_nondeterminism
   dh_compress
   dh_fixperms
   dh_missing
   dh_installdeb
   dh_gencontrol
dpkg-gencontrol: warning: Depends field of package amazon-ec2-net-utils: substitution variable ${shlibs:Depends} used, but is not defined
   dh_md5sums
   dh_builddeb
dpkg-deb: building package 'amazon-ec2-net-utils' in '../amazon-ec2-net-utils_2.5.3_all.deb'.
 dpkg-genbuildinfo --build=binary -O../amazon-ec2-net-utils_2.5.3_amd64.buildinfo
 dpkg-genchanges --build=binary -O../amazon-ec2-net-utils_2.5.3_amd64.changes
dpkg-genchanges: info: binary-only upload (no source code included)
 dpkg-source --after-build .
dpkg-source: info: unapplying update-networkd-priorities.patch
dpkg-buildpackage: info: binary-only upload (no source included)
```

**AFTER**
```
root@ip-172-31-20-194:/home/ubuntu/amazon-ec2-net-utils# dpkg-buildpackage -uc -us -b
dpkg-buildpackage: info: source package amazon-ec2-net-utils
dpkg-buildpackage: info: source version 2.5.3
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Josiah Vehrs <jvehrs@amazon.com>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
dpkg-source: info: using patch list from debian/patches/series
dpkg-source: info: applying update-networkd-priorities.patch
 debian/rules clean
dh clean
   dh_auto_clean
   dh_clean
 debian/rules build
dh build
   dh_update_autotools_config
   dh_autoreconf
   dh_auto_configure
   dh_auto_test
        make -j16 check
make[1]: Entering directory '/home/ubuntu/amazon-ec2-net-utils'
+ shellcheck --severity warning bin/setup-policy-routes.sh
+ shellcheck --severity warning lib/lib.sh
make[1]: Leaving directory '/home/ubuntu/amazon-ec2-net-utils'
   create-stamp debian/debhelper-build-stamp
 debian/rules binary
dh binary
   dh_testroot
   dh_prep
   dh_installdirs
   dh_auto_install --destdir=debian/amazon-ec2-net-utils/
        make -j16 install DESTDIR=/home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils AM_UPDATE_INFO_DIR=no "INSTALL=install --strip-program=true"
make[1]: Entering directory '/home/ubuntu/amazon-ec2-net-utils'
install -d /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils//usr/share/amazon-ec2-net-utils
tgt=/home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/bin/$(basename --suffix=.sh bin/setup-policy-routes.sh); install -m755 bin/setup-policy-routes.sh $tgt;sed -i "s,AMAZON_EC2_NET_UTILS_LIBDIR,/usr/share/amazon-ec2-net-utils,g" $tgt;
install -m644 lib/lib.sh /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils//usr/share/amazon-ec2-net-utils
install -m644 udev/99-vpc-policy-routes.rules /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/udev/rules.d;
install -m644 systemd/network/80-ec2.network /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/network;
install -m644 systemd/system/policy-routes@.service /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/system; install -m644 systemd/system/refresh-policy-routes@.service /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/system; install -m644 systemd/system/refresh-policy-routes@.timer /home/ubuntu/amazon-ec2-net-utils/debian/amazon-ec2-net-utils/usr/lib/systemd/system;
make[1]: Leaving directory '/home/ubuntu/amazon-ec2-net-utils'
   dh_installdocs
   dh_installchangelogs
   dh_installsystemd
   dh_perl
   dh_link
   dh_strip_nondeterminism
   dh_compress
   dh_fixperms
   dh_missing
   dh_installdeb
   dh_gencontrol
   dh_md5sums
   dh_builddeb
dpkg-deb: building package 'amazon-ec2-net-utils' in '../amazon-ec2-net-utils_2.5.3_all.deb'.
 dpkg-genbuildinfo --build=binary -O../amazon-ec2-net-utils_2.5.3_amd64.buildinfo
 dpkg-genchanges --build=binary -O../amazon-ec2-net-utils_2.5.3_amd64.changes
dpkg-genchanges: info: binary-only upload (no source code included)
 dpkg-source --after-build .
dpkg-source: info: unapplying update-networkd-priorities.patch
dpkg-buildpackage: info: binary-only upload (no source included)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
