### PR TITLE
Fix debian/changelog format for 2.7.1 entry

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
-amazon-ec2-net-utils (2.7.1) unstable; urgency=medium Fri, 19 Sep 2025 22:46:33 +0000
+amazon-ec2-net-utils (2.7.1) unstable; urgency=medium
 
   * New upstream release 2.7.1
+
+ -- Joe Kurokawa <joekurok@amazon.com>  Fri, 19 Sep 2025 22:46:33 +0000
 
 amazon-ec2-net-utils (2.7.0) unstable; urgency=medium
 


### PR DESCRIPTION
## Summary

Fix the `debian/changelog` format for the 2.7.1 entry so `dpkg-buildpackage` and related tools no longer emit changelog warnings.

## Problem

When building the .deb (e.g. `dpkg-buildpackage -uc -us -b`), the build logs show repeated warnings:

- `debian/changelog(l1): bad key-value after ';': '19 Sep 2025 22:46:33 +0000'`
- `debian/changelog(l5): found start of entry where expected more change data or trailer`
- `debian/changelog(l5): found end of file where expected more change data or trailer`

These come from the 2.7.1 block in `debian/changelog` not following [deb-changelog(5)](https://www.debian.org/doc/debian-policy/ch-source.html#debian-changelog-debian-changelog).

## Cause

1. **Bad key-value:** The first line of the 2.7.1 entry was:
   `amazon-ec2-net-utils (2.7.1) unstable; urgency=medium Fri, 19 Sep 2025 22:46:33 +0000`  
   The date must not appear on the header line; everything after `;` is parsed as key=value, so the date is treated as an invalid value.

2. **Missing trailer:** The 2.7.1 entry had no trailer line (` -- Maintainer <email>  Date`). The next line was the 2.7.0 entry, so the parser expected a trailer (and optionally more change lines) for 2.7.1.

## Changes

In `debian/changelog`:

- **Line 1:** Use only `amazon-ec2-net-utils (2.7.1) unstable; urgency=medium` (remove the date from this line).
- **After the 2.7.1 change line and blank line:** Add the trailer for 2.7.1, e.g. ` -- Joe Kurokawa Fri, 19 Sep 2025 22:46:33 +0000`, so the 2.7.1 block is complete before the 2.7.0 entry.

Resulting 2.7.1 block with no warnings any more (except the other warning fixed in #139):

```
amazon-ec2-net-utils (2.7.1) unstable; urgency=medium

  * New upstream release 2.7.1

 -- Joe Kurokawa <joekurok@amazon.com>  Fri, 19 Sep 2025 22:46:33 +0000
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
