### PR TITLE
fix(lib): maybe_reload_networkd must not fail EXIT trap when EC2_IF_INITIAL_SETUP is unset

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -617,7 +617,9 @@ maybe_reload_networkd() {
             networkctl reload
             debug "Reloaded networkd"
         else
-            [ -v EC2_IF_INITIAL_SETUP ] && debug "No networkd reload needed"
+            if [ -v EC2_IF_INITIAL_SETUP ]; then
+                debug "No networkd reload needed"
+            fi
         fi
     else
         debug "Deferring networkd reload to another process"

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -140,7 +140,9 @@ get_meta() {
     local key=$1
     local max_tries=${2:-10}
     declare -i attempts=0
-    [ -v EC2_IF_INITIAL_SETUP ] && debug "[get_meta] Querying IMDS for ${key}"
+    if [ -v EC2_IF_INITIAL_SETUP ]; then
+        debug "[get_meta] Querying IMDS for ${key}"
+    fi
 
     if [[ -z $imds_endpoint || -z $imds_token || -z $imds_interface ]]; then
         error "[get_meta] Unable to obtain IMDS token, endpoint, or interface"
@@ -640,7 +642,7 @@ register_networkd_reloader() {
     while [ $cnt -lt $max ]; do
         cnt+=1
         mkdir -p "$lockdir"
-        trap '[ -v EC2_IF_INITIAL_SETUP ] && debug "Called trap" ; maybe_reload_networkd' EXIT
+        trap 'if [ -v EC2_IF_INITIAL_SETUP ]; then debug "Called trap"; fi; maybe_reload_networkd' EXIT
         # If the redirect fails, most likely because the target file
         # already exists and -o noclobber is in effect, $? will be set
         # nonzero.  If it succeeds, it is set to 0


### PR DESCRIPTION
`refresh-policy-routes@.service` (oneshot) often exited **1** after a successful run because `maybe_reload_networkd` returned non-zero from the `EXIT` trap when no `networkctl reload` was required and `EC2_IF_INITIAL_SETUP` was unset.

### Before

```bash
journalctl -u 'refresh-policy-routes@ens5.service' -o cat
```

```text
Got IMDSv2 token for interface ens5 from http://169.254.169.254/latest via ens5
refresh-policy-routes@ens5.service: Main process exited, code=exited, status=1/FAILURE
refresh-policy-routes@ens5.service: Failed with result 'exit-code'.
Failed to start refresh-policy-routes@ens5.service - Refresh policy routes for ens5.
```

### After

```text
Got IMDSv2 token for interface ens5 from http://169.254.169.254/latest via ens5
refresh-policy-routes@ens5.service: Deactivated successfully.
Finished refresh-policy-routes@ens5.service - Refresh policy routes for ens5.
```

### Change

In `maybe_reload_networkd`, replace:

`[ -v EC2_IF_INITIAL_SETUP ] && debug "No networkd reload needed"`

with an `if [ -v EC2_IF_INITIAL_SETUP ]; then debug ...; fi` so the else branch does not end on a failing `[` when the variable is unset.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
