### PR TITLE
fix(lib): write drop-in configs to active network file directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Dev Container
+/.devcontainer/
+
+# VS Code
+.vscode
+*.code-workspace
+
+# IDE
+.cursor
+.kiro
+
+# Miscellaneous files
+*.DS_Store

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -230,13 +230,27 @@ _install_and_reload() {
     fi
 }
 
+_get_active_dropin_dir() {
+    local iface=$1
+    local default_dir="${unitdir}/70-${iface}.network.d"
+    local ifindex network_file
+    ifindex=$(cat "/sys/class/net/${iface}/ifindex" 2> /dev/null) || { echo "$default_dir"; return; }
+    network_file=$(sed -n 's/^NETWORK_FILE=//p' "/run/systemd/netif/links/${ifindex}" 2> /dev/null) || { echo "$default_dir"; return; }
+    if [ -n "$network_file" ]; then
+        echo "${network_file}.d"
+    else
+        echo "$default_dir"
+    fi
+}
+
 create_ipv4_aliases() {
     local iface=$1
     local mac=$2
     local addresses
     subnet_supports_ipv4 "$iface" || return 0
     addresses=$(get_iface_imds $mac local-ipv4s | tail -n +2 | sort)
-    local drop_in_dir="${unitdir}/70-${iface}.network.d"
+    local drop_in_dir
+    drop_in_dir=$(_get_active_dropin_dir "$iface")
     mkdir -p "$drop_in_dir"
     local file="$drop_in_dir/ec2net_alias.conf"
     local work="${file}.new"
@@ -295,7 +309,8 @@ create_rules() {
     local family=$4
     local addrs prefixes
     local local_addr_key subnet_pd_key
-    local drop_in_dir="${unitdir}/70-${iface}.network.d"
+    local drop_in_dir
+    drop_in_dir=$(_get_active_dropin_dir "$iface")
     mkdir -p "$drop_in_dir"
 
     local -i ruleid=$((device_number+rule_base+100*network_card))


### PR DESCRIPTION
# fix(lib): write drop-in configs to active network file directory

Fixes: #146 

## Summary

- Adds `_get_active_dropin_dir()` helper that discovers the actual active `.network` file for an interface via systemd-networkd runtime state
- `create_ipv4_aliases()` and `create_rules()` use the helper instead of hardcoded `70-<iface>.network.d` paths
- Fixes secondary IPv4 aliases and policy routing rules being silently ignored on distributions where another network config generator (netplan, cloud-init) creates a lower-numbered `.network` file

## Problem

`systemd-networkd` selects exactly one `.network` file per interface — the one with the lowest numerical prefix that matches. Drop-in files are only read from the **active** file's `.d/` directory.

`create_ipv4_aliases()` and `create_rules()` hardcode their drop-in directory to `70-<iface>.network.d/`. When netplan or cloud-init generates a `10-netplan-<iface>.network`, systemd-networkd uses that file and silently ignores `70-<iface>.network` and all its drop-ins.

This means `ec2net_alias.conf` (secondary IPv4 addresses) and `ec2net_policy_*.conf` (policy routing rules) are written to disk correctly but never applied.

## Solution

A new helper `_get_active_dropin_dir()`:

1. Reads the interface's `ifindex` from sysfs.
2. Parses the `NETWORK_FILE=` line from `/run/systemd/netif/links/<ifindex>`.
3. Returns `<NETWORK_FILE>.d` as the drop-in directory.
4. Falls back to the original `70-<iface>.network.d` when detection fails (e.g. early boot, missing sysfs node).

```diff
+_get_active_dropin_dir() {
+    local iface=$1
+    local default_dir="${unitdir}/70-${iface}.network.d"
+    local ifindex network_file
+    ifindex=$(cat "/sys/class/net/${iface}/ifindex" 2> /dev/null) || { echo "$default_dir"; return; }
+    network_file=$(sed -n 's/^NETWORK_FILE=//p' "/run/systemd/netif/links/${ifindex}" 2> /dev/null) || { echo "$default_dir"; return; }
+    if [ -n "$network_file" ]; then
+        echo "${network_file}.d"
+    else
+        echo "$default_dir"
+    fi
+}
```

## Test plan

Tested on Ubuntu 24.04 (c6i.2xlarge) where netplan generates `/run/systemd/network/10-netplan-ens5.network`.

### 1. Add a single secondary IP

```bash
aws ec2 assign-private-ip-addresses \
    --network-interface-id eni-058ecf72704d3be0c \
    --secondary-private-ip-address-count 1
# Wait ~30s for refresh timer

ip addr show ens5
# 2: ens5: ...
#     inet 172.31.79.251/32 scope global noprefixroute ens5   <-- secondary
#     inet 172.31.79.44/20 metric 100 brd ... scope global dynamic ens5

networkctl status ens5
# Network File: /run/systemd/network/10-netplan-ens5.network
#               └─/run/systemd/network/10-netplan-ens5.network.d/ec2net_alias.conf
# Address: 172.31.79.44 (DHCP4 via 172.31.64.1)
#          172.31.79.251
```

### 2. Add multiple secondary IPs

```bash
aws ec2 assign-private-ip-addresses \
    --network-interface-id eni-058ecf72704d3be0c \
    --secondary-private-ip-address-count 3
# Wait ~30s

ip addr show ens5 | grep inet
#     inet 172.31.64.253/32 scope global noprefixroute ens5
#     inet 172.31.71.37/32 scope global noprefixroute ens5
#     inet 172.31.73.123/32 scope global noprefixroute ens5
#     inet 172.31.79.44/20 metric 100 ...
```

### 3. Partial removal (remove 1 of 3)

```bash
aws ec2 unassign-private-ip-addresses \
    --network-interface-id eni-058ecf72704d3be0c \
    --private-ip-addresses 172.31.73.123
# Wait ~30s

ip addr show ens5 | grep inet
#     inet 172.31.64.253/32 scope global noprefixroute ens5
#     inet 172.31.71.37/32 scope global noprefixroute ens5
#     inet 172.31.79.44/20 metric 100 ...
```

### 4. Remove all secondary IPs

```bash
aws ec2 unassign-private-ip-addresses \
    --network-interface-id eni-058ecf72704d3be0c \
    --private-ip-addresses $(aws ec2 describe-network-interfaces \
        --network-interface-ids eni-058ecf72704d3be0c \
        --query 'NetworkInterfaces[0].PrivateIpAddresses[?Primary==`false`].PrivateIpAddress' \
        --output text)
# Wait ~30s

ip addr show ens5 | grep inet
#     inet 172.31.79.44/20 metric 100 ...   <-- only primary remains
```

### 5. Syslog confirms drop-in written to correct path

```text
ec2net[...]: install_and_reload detected change for: /run/systemd/network/10-netplan-ens5.network.d/ec2net_alias.conf
ec2net[...]: Reloaded networkd
```

### 6. Fallback behaviour

When `70-ens5.network` IS the active file (no netplan/cloud-init conflict), the helper returns `70-ens5.network.d` and behaviour is identical to before this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.