### PR TITLE
setup-policy-routes start: infinite sysfs wait loop causes unbounded process accumulation on ECS hosts

### DIFF
--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -56,7 +56,7 @@ start)
             debug "Waiting for sysfs node to exist for ${iface} (iteration $counter)"
         fi
         sleep 0.1
-        ((counter++))
+        ((counter++)) || true
         if ((counter >= max_wait)); then
             error "Timed out waiting for sysfs node for ${iface} after $((counter / 10)) seconds"
             exit 1

--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -50,12 +50,17 @@ refresh)
 start)
     register_networkd_reloader
     counter=0
+    max_wait=3000   # 5 minute timeout to avoid infinite loop if sysfs node never appears
     while [ ! -e "/sys/class/net/${iface}" ]; do
         if ((counter % 1000 == 0)); then
             debug "Waiting for sysfs node to exist for ${iface} (iteration $counter)"
         fi
         sleep 0.1
         ((counter++))
+        if ((counter >= max_wait)); then
+            error "Timed out waiting for sysfs node for ${iface} after $((counter / 10)) seconds"
+            exit 1
+        fi
     done
     debug "Starting configuration for $iface"
     debug /lib/systemd/systemd-networkd-wait-online -i "$iface"

--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -59,7 +59,8 @@ start)
         ((counter++)) || true
         if ((counter >= max_wait)); then
             error "Timed out waiting for sysfs node for ${iface} after $((counter / 10)) seconds"
-            exit 1
+            /usr/bin/systemctl disable --now refresh-policy-routes@${iface}.timer 2>/dev/null || true
+            exit 2
         fi
     done
     debug "Starting configuration for $iface"

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -627,7 +627,7 @@ maybe_reload_networkd() {
 
 register_networkd_reloader() {
     local -i registered=1 cnt=0
-    local -i max=10000
+    local -i max=3000   # 300s (3000 × 0.1s); matches sysfs wait timeout in setup-policy-routes.sh
     local -r lockfile="${lockdir}/${iface}"
     local old_opts=$-
 

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -631,6 +631,18 @@ register_networkd_reloader() {
     local -r lockfile="${lockdir}/${iface}"
     local old_opts=$-
 
+    # If the existing lock owner is no longer alive, remove the stale lockfile
+    # so subsequent invocations don't spin for up to 1000 seconds waiting on a
+    # process that will never release it.
+    if [ -f "${lockfile}" ]; then
+        local existing_pid
+        existing_pid=$(cat "${lockfile}" 2>/dev/null)
+        if [ -n "$existing_pid" ] && ! kill -0 "$existing_pid" 2>/dev/null; then
+            debug "Removing stale lock from dead process $existing_pid for ${iface}"
+            rm -f "${lockfile}"
+        fi
+    fi
+
     # Disable -o errexit in the following block so we can capture
     # nonzero exit codes from a redirect without considering them
     # fatal errors

--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -17,4 +17,5 @@ User=root
 ExecStart=/usr/bin/setup-policy-routes %i start
 Restart=on-failure
 RestartSec=1
+RestartPreventExitStatus=2
 KillMode=process


### PR DESCRIPTION
### *Issue #, if available:*
#148 

### *Description of changes:*

Fixes infinite process accumulation on ECS hosts caused by setup-policy-routes start looping forever when an ENI is detached before its sysfs node appears (can repeatedly occur during rapid ENI attach/detach cycles, i.e. ECS task churn)

Two changes:

- bin/setup-policy-routes.sh: add a 5-minute timeout to the sysfs wait loop in the start action so stuck processes eventually exit instead of holding the per-ENI lockfile indefinitely
- lib/lib.sh: add a stale lock check in register_networkd_reloader(). If the lock owner PID is no longer alive, remove the lockfile before spinning

See #148 for full root cause analysis, reproduction steps, and evidence from affected hosts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
