### PR TITLE
Add .gitignore for common IDE/devcontainer workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Dev Container
+/.devcontainer/
+
+# VS Code
+.vscode
+*.code-workspace
+
+# IDE
+.cursor
+.kiro
+
+# Miscellaneous files
+*.DS_Store


### PR DESCRIPTION
Add a .gitignore file to exclude common development artifacts from version control:

- Dev Container configuration (`.devcontainer/`)
- VS Code / Cursor / Kiro IDE files (`.vscode`, `.cursor`, `.kiro`, `*.code-workspace`)
- macOS metadata files (`*.DS_Store`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
