### PR TITLE
_get_network_card does not retry on empty IMDS responses, causing route metric and table ID collisions on multi-card instances

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -18,6 +18,7 @@ declare ether
 declare unitdir
 declare lockdir
 declare reload_flag
+declare runtimeroot
 
 # Version information - substituted during installation
 declare PACKAGE_VERSION="AMAZON_EC2_NET_UTILS_VERSION"
@@ -532,6 +533,16 @@ _get_device_number() {
 # NOTE: On many instance types, this value is not defined.  This
 # function will print the empty string on those instances.  On
 # instances where it is defined, it will be a numeric value.
+#
+# The value, like device-number, may not have propagated to IMDS
+# when a hot-plugged interface first appears.  We can't tell
+# "undefined for this instance type" from "not yet propagated" from
+# a single query, so we retry on empty.  Once the first ENI on this
+# boot has exhausted the retry loop with no value, we touch a marker
+# so subsequent ENIs skip the retry entirely. Without
+# this retry we can silently substitute 0 for a real network-card
+# index on multi-card instances, colliding route metrics and
+# routing-table IDs across interfaces.
 _get_network_card() {
     local iface ether network_card
     iface="$1"
@@ -540,8 +551,26 @@ _get_network_card() {
     if _is_primary_interface "$ether"; then
         echo 0 ; return 0
     fi
-    network_card=$(get_iface_imds "$ether" network-card)
+
+    local marker="${runtimeroot}/.no-network-card"
+    if [ -e "$marker" ]; then
+        echo ${network_card}
+        return 0
+    fi
+
+    local -i maxtries=40 ntries=0
+    for (( ntries = 0; ntries < maxtries; ntries++ )); do
+        network_card=$(get_iface_imds "$ether" network-card 1)
+        if [ -n "$network_card" ]; then
+            echo "$network_card"
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    touch "$marker"
     echo ${network_card}
+    return 0
 }
 
 


### PR DESCRIPTION
## Description

`_get_network_card` in `lib/lib.sh` queries IMDS for an interface's `network-card` value exactly once and echoes whatever comes back, including an empty string. `_get_device_number` already handles the same propagation race with a 60-attempt retry loop; `_get_network_card` does not.

When a hot-plugged ENI's `network-card` value has not yet propagated to IMDS, the empty result flows downstream into:

sh
local -i network_card="$3"
local -i metric=$((metric_base + 100*network_card + device_number))
local -i tableid=$((rule_base + 100*network_card + device_number))

Bash coerces the empty string to `0`. Two interfaces on different network cards can therefore both be configured with `network_card=0`, producing duplicate route metrics and routing-table IDs. The same collision affects `create_rules`, which uses `device_number + rule_base + 100*network_card` for its policy-rule priority and table.

## Impact

The race is rare on small instances but reproducible on instance types that expose multiple network cards and attach many ENIs. We've observed it with 60 ENIs. Symptoms include non-deterministic route ordering, policy-rule conflicts, and traffic egressing the wrong interface.

## Reproduction (sketch)

1. Launch a multi-card instance type.
2. Hot-attach ENIs in rapid succession across multiple network cards.
3. Observe `networkctl status` and `ip rule show` for interfaces that share the same metric / table ID, or `journalctl -u 'policy-routes@*'` for racing setup runs.

## Affected code

`lib/lib.sh`, `_get_network_card` (around line 535).

## Proposed fix

Mirror `_get_device_number`'s retry structure: up to 60 attempts with a 0.1s sleep between tries, single curl per iteration. Accept an empty result after exhaustion to preserve the documented behavior on instance types that legitimately don't expose `network-card`.

sh
getnetwork_card() {
   local iface ether network_card
   iface="$1"
   ether="$2"

   if isprimary_interface "$ether"; then
       echo 0 ; return 0
   fi

   local -i maxtries=60 ntries=0
   for (( ntries = 0; ntries < maxtries; ntries++ )); do
       network_card=$(get_iface_imds "$ether" network-card 1)
       if [ -n "$network_card" ]; then
           echo "$network_card"
           return 0
       fi
       sleep 0.1
   done
   echo ""
   return 0
}
