### PR TITLE
Remove .gitattributes so release archives include debian/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-debian/ export-ignore


### PR DESCRIPTION
The lone 'debian/ export-ignore' directive caused git archive — which
GitHub uses to build release zip/tar.gz assets, and which the project's
own 'make release-sources' target also uses — to strip the entire
debian/ directory. That dropped debian/patches/update-networkd-priorities.patch,
which is required for correct operation on netplan-based systems,
breaking any deb build sourced from a release tarball.

Fixes #155
