### PR TITLE
increase sysfs timeout

### DIFF
--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -50,7 +50,7 @@ refresh)
 start)
     register_networkd_reloader
     counter=0
-    max_wait=3000   # 5 minute timeout to avoid infinite loop if sysfs node never appears
+    max_wait=6000   # 10 minute timeout to avoid infinite loop if sysfs node never appears
     while [ ! -e "/sys/class/net/${iface}" ]; do
         if ((counter % 1000 == 0)); then
             debug "Waiting for sysfs node to exist for ${iface} (iteration $counter)"

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -660,7 +660,7 @@ maybe_reload_networkd() {
 
 register_networkd_reloader() {
     local -i registered=1 cnt=0
-    local -i max=3000   # 300s (3000 × 0.1s); matches sysfs wait timeout in setup-policy-routes.sh
+    local -i max=6000   # 600s (6000 × 0.1s); matches sysfs wait timeout in setup-policy-routes.sh
     local -r lockfile="${lockdir}/${iface}"
     local old_opts=$-
 


### PR DESCRIPTION
*Issue #, if available:*
This just increases the timeout for loop to detect sysfs node. 

*Description of changes:*
Increasing timeout to 10 minutes as this is a more reasonable time for sysfs being down during high load.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
