### PR TITLE
Remove restarts from setup-refresh-policy routes to fixed leaked timers.

### DIFF
--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -3,6 +3,7 @@ Description=Set up policy routes for %I
 StartLimitIntervalSec=10
 StartLimitBurst=5
 Wants=refresh-policy-routes@%i.timer
+CollectMode=inactive-or-failed
 
 [Install]
 Also=refresh-policy-routes@%i.timer

--- a/systemd/system/refresh-policy-routes@.service
+++ b/systemd/system/refresh-policy-routes@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Refresh policy routes for %I
+CollectMode=inactive-or-failed
 
 [Service]
 Type=oneshot

--- a/systemd/system/refresh-policy-routes@.timer
+++ b/systemd/system/refresh-policy-routes@.timer
@@ -1,3 +1,6 @@
+[Unit]
+BindsTo=policy-routes@%i.service
+
 [Timer]
 OnActiveSec=30
 OnUnitInactiveSec=60


### PR DESCRIPTION
*Issue* https://github.com/amazonlinux/amazon-ec2-net-utils/issues/152
Fix leaked timer caused by a race condition when rapid attach and detach happens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
